### PR TITLE
Updated versioning for blackjax for Python 3.10 and higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 dependencies = [
     "jaxlib",
     "jax",
-    "blackjax <= 1.2.3"
+    "blackjax <= 1.2.3; python_version < '3.10'",
+    "blackjax; python_version >= '3.10'"
 ]
 keywords = ["jax", 
     "parameter-inference", 


### PR DESCRIPTION
For Python 3.10 or higher, non-specified version of blackjax is installed.